### PR TITLE
sc-13403 Added timezone parameter

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -9,7 +9,7 @@ dhis2_endpoints:
 sendgrid_accounts:
   - account_name: "Account1"
     api_key: "key"
-    time_zone: "time_zone"
+    time_zone: "timezone"
   - account_name: "Account2"
     api_key: "key"
-    time_zone: "time_zone"
+    time_zone: "timezone"

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -9,5 +9,7 @@ dhis2_endpoints:
 sendgrid_accounts:
   - account_name: "Account1"
     api_key: "key"
+    time_zone: "time_zone"
   - account_name: "Account2"
     api_key: "key"
+    time_zone: "time_zone"

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ type Config struct {
 	SendGridAccounts []struct {
 		AccountName string `yaml:"account_name"`
 		APIKey      string `yaml:"api_key"`
-		TimeZone    string `yaml:"time_zone"` // Added TimeZone field
+		TimeZone    string `yaml:"time_zone"`
 	} `yaml:"sendgrid_accounts"`
 	DHIS2Endpoints []struct {
 		BaseURL  string `yaml:"base_url"`
@@ -45,10 +45,8 @@ func readConfig(configPath string) (*Config, error) {
 }
 
 func gracefulShutdown(server *http.Server) {
-	// Create a context with a timeout for the shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	// Notify when the shutdown process is complete
 	idleConnectionsClosed := make(chan struct{})
 	go func() {
 		defer close(idleConnectionsClosed)
@@ -107,7 +105,7 @@ func main() {
 		}
 		timeZones[account.AccountName] = loc
 	}
-	sendgridExporter := sendgrid.NewExporter(apiKeys, timeZones) // Passed timeZones to Exporter
+	sendgridExporter := sendgrid.NewExporter(apiKeys, timeZones)
 	prometheus.MustRegister(sendgridExporter)
 
 	http.Handle("/metrics", promhttp.Handler())

--- a/main.go
+++ b/main.go
@@ -1,5 +1,4 @@
 package main
-
 import (
 	"context"
 	"io/ioutil"
@@ -8,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/simpledotorg/rtsl_exporter/alphasms"
@@ -16,12 +14,12 @@ import (
 	"github.com/simpledotorg/rtsl_exporter/sendgrid"
 	"gopkg.in/yaml.v2"
 )
-
 type Config struct {
 	ALPHASMSAPIKey   string `yaml:"alphasms_api_key"`
 	SendGridAccounts []struct {
 		AccountName string `yaml:"account_name"`
 		APIKey      string `yaml:"api_key"`
+		TimeZone    string `yaml:"time_zone"` // Added TimeZone field
 	} `yaml:"sendgrid_accounts"`
 	DHIS2Endpoints []struct {
 		BaseURL  string `yaml:"base_url"`
@@ -29,7 +27,6 @@ type Config struct {
 		Password string `yaml:"password"`
 	} `yaml:"dhis2_endpoints"`
 }
-
 func readConfig(configPath string) (*Config, error) {
 	config := &Config{}
 	yamlFile, err := ioutil.ReadFile(configPath)
@@ -42,12 +39,10 @@ func readConfig(configPath string) (*Config, error) {
 	}
 	return config, nil
 }
-
 func gracefulShutdown(server *http.Server) {
 	// Create a context with a timeout for the shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-
 	// Notify when the shutdown process is complete
 	idleConnectionsClosed := make(chan struct{})
 	go func() {
@@ -56,7 +51,6 @@ func gracefulShutdown(server *http.Server) {
 			log.Printf("HTTP Server Shutdown Error: %v", err)
 		}
 	}()
-
 	// Wait for the server to shut down
 	select {
 	case <-ctx.Done():
@@ -65,15 +59,12 @@ func gracefulShutdown(server *http.Server) {
 		log.Println("HTTP Server Shutdown Complete")
 	}
 }
-
 func main() {
 	log.SetFlags(0)
-
 	config, err := readConfig("config.yaml")
 	if err != nil {
 		log.Fatalf("Error reading config file: %v", err)
 	}
-
 	// Alphasms
 	if config.ALPHASMSAPIKey == "" {
 		log.Fatalf("ALPHASMS_API_KEY not provided in config file")
@@ -81,7 +72,6 @@ func main() {
 	alphasmsClient := alphasms.Client{APIKey: config.ALPHASMSAPIKey}
 	alphasmsExporter := alphasms.NewExporter(&alphasmsClient)
 	prometheus.MustRegister(alphasmsExporter)
-
 	// DHIS2
 	dhis2Clients := []*dhis2.Client{}
 	for _, endpoint := range config.DHIS2Endpoints {
@@ -95,22 +85,25 @@ func main() {
 	}
 	dhis2Exporter := dhis2.NewExporter(dhis2Clients)
 	prometheus.MustRegister(dhis2Exporter)
-
-	// Register SendGrid exporters
+	// Register SendGrid exporters with time zones
 	apiKeys := make(map[string]string)
+	timeZones := make(map[string]*time.Location) // Added timeZones map
 	for _, account := range config.SendGridAccounts {
 		apiKeys[account.AccountName] = account.APIKey
+		loc, err := time.LoadLocation(account.TimeZone)
+		if err != nil {
+			log.Printf("Error loading time zone for account %s: %v", account.AccountName, err)
+			loc = time.UTC // Default to UTC if time zone cannot be loaded
+		}
+		timeZones[account.AccountName] = loc
 	}
-	sendgridExporter := sendgrid.NewExporter(apiKeys)
+	sendgridExporter := sendgrid.NewExporter(apiKeys, timeZones) // Passed timeZones to Exporter
 	prometheus.MustRegister(sendgridExporter)
-
 	http.Handle("/metrics", promhttp.Handler())
 	log.Println("Starting server on :8080")
-
 	httpServer := &http.Server{
 		Addr: ":8080",
 	}
-
 	go func() {
 		sigint := make(chan os.Signal, 1)
 		signal.Notify(sigint, os.Interrupt)
@@ -118,10 +111,8 @@ func main() {
 		log.Println("Shutdown signal received")
 		gracefulShutdown(httpServer)
 	}()
-
 	if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 		log.Fatalf("HTTP server ListenAndServe Error: %v", err)
 	}
-
 	log.Println("Bye bye")
 }

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	// Register SendGrid exporters with time zones
 	apiKeys := make(map[string]string)
-	timeZones := make(map[string]*time.Location) // Added timeZones map
+	timeZones := make(map[string]*time.Location)
 	for _, account := range config.SendGridAccounts {
 		apiKeys[account.AccountName] = account.APIKey
 		loc, err := time.LoadLocation(account.TimeZone)

--- a/main.go
+++ b/main.go
@@ -2,29 +2,24 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"os"
-	"os/signal"
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/simpledotorg/rtsl_exporter/alphasms"
 	"github.com/simpledotorg/rtsl_exporter/dhis2"
 	"github.com/simpledotorg/rtsl_exporter/sendgrid"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
 )
 
 type Config struct {
-	ALPHASMSAPIKey   string `yaml:"alphasms_api_key"`
-	SendGridAccounts []struct {
-		AccountName string `yaml:"account_name"`
-		APIKey      string `yaml:"api_key"`
-		TimeZone    string `yaml:"time_zone"`
-	} `yaml:"sendgrid_accounts"`
-	DHIS2Endpoints []struct {
+	ALPHASMSAPIKey   string                   `yaml:"alphasms_api_key"`
+	SendGridAccounts []sendgrid.AccountConfig `yaml:"sendgrid_accounts"`
+	DHIS2Endpoints   []struct {
 		BaseURL  string `yaml:"base_url"`
 		Username string `yaml:"username"`
 		Password string `yaml:"password"`
@@ -43,10 +38,11 @@ func readConfig(configPath string) (*Config, error) {
 	}
 	return config, nil
 }
-
 func gracefulShutdown(server *http.Server) {
+	// Create a context with a timeout for the shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	// Notify when the shutdown process is complete
 	idleConnectionsClosed := make(chan struct{})
 	go func() {
 		defer close(idleConnectionsClosed)
@@ -62,15 +58,12 @@ func gracefulShutdown(server *http.Server) {
 		log.Println("HTTP Server Shutdown Complete")
 	}
 }
-
 func main() {
 	log.SetFlags(0)
-
 	config, err := readConfig("config.yaml")
 	if err != nil {
 		log.Fatalf("Error reading config file: %v", err)
 	}
-
 	// Alphasms
 	if config.ALPHASMSAPIKey == "" {
 		log.Fatalf("ALPHASMS_API_KEY not provided in config file")
@@ -78,7 +71,6 @@ func main() {
 	alphasmsClient := alphasms.Client{APIKey: config.ALPHASMSAPIKey}
 	alphasmsExporter := alphasms.NewExporter(&alphasmsClient)
 	prometheus.MustRegister(alphasmsExporter)
-
 	// DHIS2
 	dhis2Clients := []*dhis2.Client{}
 	for _, endpoint := range config.DHIS2Endpoints {
@@ -92,29 +84,22 @@ func main() {
 	}
 	dhis2Exporter := dhis2.NewExporter(dhis2Clients)
 	prometheus.MustRegister(dhis2Exporter)
-
 	// Register SendGrid exporters with time zones
-	apiKeys := make(map[string]string)
-	timeZones := make(map[string]*time.Location)
+	sendGridConfigMap := make(map[string]sendgrid.AccountConfig)
 	for _, account := range config.SendGridAccounts {
-		apiKeys[account.AccountName] = account.APIKey
-		loc, err := time.LoadLocation(account.TimeZone)
-		if err != nil {
-			log.Printf("Error loading time zone for account %s: %v", account.AccountName, err)
-			loc = time.UTC // Default to UTC if time zone cannot be loaded
+		sendGridConfigMap[account.AccountName] = sendgrid.AccountConfig{
+			AccountName: account.AccountName,
+			APIKey:      account.APIKey,
+			TimeZone:    account.TimeZone,
 		}
-		timeZones[account.AccountName] = loc
 	}
-	sendgridExporter := sendgrid.NewExporter(apiKeys, timeZones)
+	sendgridExporter := sendgrid.NewExporter(sendGridConfigMap)
 	prometheus.MustRegister(sendgridExporter)
-
 	http.Handle("/metrics", promhttp.Handler())
 	log.Println("Starting server on :8080")
-
 	httpServer := &http.Server{
 		Addr: ":8080",
 	}
-
 	go func() {
 		sigint := make(chan os.Signal, 1)
 		signal.Notify(sigint, os.Interrupt)
@@ -122,10 +107,8 @@ func main() {
 		log.Println("Shutdown signal received")
 		gracefulShutdown(httpServer)
 	}()
-
 	if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 		log.Fatalf("HTTP server ListenAndServe Error: %v", err)
 	}
-
 	log.Println("Bye bye")
 }

--- a/sendgrid/exporter.go
+++ b/sendgrid/exporter.go
@@ -8,19 +8,19 @@ import (
 )
 
 type Exporter struct {
-	client         *Client
-	timeZones      map[string]*time.Location
-	emailLimit     *prometheus.GaugeVec
-	emailRemaining *prometheus.GaugeVec
-	emailUsed      *prometheus.GaugeVec
-	planExpiration *prometheus.GaugeVec
-	httpReturnCode *prometheus.GaugeVec
+	client           *Client
+	timeZones        map[string]*time.Location
+	emailLimit       *prometheus.GaugeVec
+	emailRemaining   *prometheus.GaugeVec
+	emailUsed        *prometheus.GaugeVec
+	planExpiration   *prometheus.GaugeVec
+	httpReturnCode   *prometheus.GaugeVec
 	httpResponseTime *prometheus.GaugeVec
 }
 
 func NewExporter(apiKeys map[string]string, timeZones map[string]*time.Location) *Exporter {
 	return &Exporter{
-		client: NewClient(apiKeys),
+		client:    NewClient(apiKeys),
 		timeZones: timeZones,
 		emailLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "sendgrid",
@@ -73,7 +73,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			log.Printf("Failed to get metrics for account %s: %v", accountName, err)
 			continue
 		}
-		
+
 		// Set metrics values for each account
 		e.emailLimit.WithLabelValues(accountName).Set(metrics.Total)
 		e.emailRemaining.WithLabelValues(accountName).Set(metrics.Remaining)
@@ -86,7 +86,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			log.Printf("Failed to parse plan reset date for account %s: %v", accountName, parseErr)
 			continue
 		}
-		currentTime := time.Now().In(timeZone)	
+		currentTime := time.Now().In(timeZone)
 		timeUntilExpiration := planResetDate.Sub(currentTime).Seconds()
 
 		e.planExpiration.WithLabelValues(accountName).Set(timeUntilExpiration)

--- a/sendgrid/exporter.go
+++ b/sendgrid/exporter.go
@@ -35,8 +35,8 @@ func NewExporter(accounts map[string]AccountConfig) *Exporter {
 		timeZones[accountName] = loc
 	}
 	return &Exporter{
-		client:    NewClient(apiKeys), // Pass apiKeys map directly
-		timeZones: timeZones,          // Pass timeZones map
+		client:    NewClient(apiKeys),
+		timeZones: timeZones,
 		emailLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "sendgrid",
 			Name:      "email_limit_count",

--- a/sendgrid/exporter_test.go
+++ b/sendgrid/exporter_test.go
@@ -1,10 +1,11 @@
 package sendgrid
+
 import (
-	"testing"
-	"time"
 	"github.com/jarcoal/httpmock"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"testing"
 )
+
 func TestExporterCollect(t *testing.T) {
 	// Activate the HTTP mock
 	httpmock.Activate()
@@ -18,14 +19,14 @@ func TestExporterCollect(t *testing.T) {
 			"next_reset": "2024-02-20"
 		}`))
 	// Created a new Exporter
-	accountNames := map[string]string{
-		"mockAccount": "mockAPIKey",
+	accountConfigs := map[string]AccountConfig{
+		"mockAccount": {
+			AccountName: "mockAccount",
+			APIKey:      "mockAPIKey",
+			TimeZone:    "UTC",
+		},
 	}
-
-	timeZones := map[string]*time.Location{
-		"mockAccount": time.UTC,
-	}
-	exporter := NewExporter(accountNames, timeZones)
+	exporter := NewExporter(accountConfigs)
 	t.Run("Successful metrics collection", func(t *testing.T) {
 		expectedMetrics := []string{
 			"sendgrid_email_limit_count",

--- a/sendgrid/exporter_test.go
+++ b/sendgrid/exporter_test.go
@@ -1,6 +1,7 @@
 package sendgrid
 import (
 	"testing"
+	"time"
 	"github.com/jarcoal/httpmock"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -20,7 +21,11 @@ func TestExporterCollect(t *testing.T) {
 	accountNames := map[string]string{
 		"mockAccount": "mockAPIKey",
 	}
-	exporter := NewExporter(accountNames)
+
+	timeZones := map[string]*time.Location{
+		"mockAccount": time.UTC,
+	}
+	exporter := NewExporter(accountNames, timeZones)
 	t.Run("Successful metrics collection", func(t *testing.T) {
 		expectedMetrics := []string{
 			"sendgrid_email_limit_count",


### PR DESCRIPTION
Story_card: https://app.shortcut.com/simpledotorg/story/13403/minor-fixes-in-sendgrid-prometheus-exporter

What:
Added timezone to the exporter
Why:
As ethiopia_production and production(for other countries) has different timezones in their respective sendgrid accounts,
so to get the correct data to monitor in prometheus.